### PR TITLE
fixed BB3 root histo titles

### DIFF
--- a/Analyse/Configuration/Software/pxar.cfg
+++ b/Analyse/Configuration/Software/pxar.cfg
@@ -46,11 +46,11 @@ AddressLevels: AddressLevels_C%d
 
 [BumpBonding]
 Analog: BumpBond.vcals_xtalk_C%dDistribution
-Digital: BumpBonding.dist_thr_calSMap_VthrComp_C%d_V0
+Digital: BB3.dist_rescaledThr_C%d_V0
 
 [BumpBondingProblems]
 Analog: vcals_xtalk_C%d
-Digital:  BumpBonding.thr_calSMap_VthrComp_C%d_V0
+Digital: BB3.rescaledThr_C%d_V0
 
 [PHCalibrationGain]
 FitFileName: phCalibrationFit_C%d


### PR DESCRIPTION
These changes to pxar.cfg direct moreweb to the correct histograms from the newer bump bonding test, BB3. If these are incorporated into the purdue repo we can try to upload data from Fermilab. 
